### PR TITLE
docs: add Community Projects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,7 +722,7 @@ Third-party integrations and implementations built by the community.
 
 | Project | Language | Description |
 | ------- | -------- | ----------- |
-| [**wavekat&#8209;vad**](https://github.com/wavekat/wavekat-vad) | Rust | Pure Rust ONNX implementation with native preprocessing. No C dependencies. |
+| [**wavekat&#8209;vad**](https://github.com/wavekat/wavekat-vad) | Rust | Multi-backend VAD crate on [crates.io](https://crates.io/crates/wavekat-vad) with TEN VAD support via pure Rust ONNX inference. |
 
 > Have a project using TEN VAD? Feel free to open a PR to add it here!
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
     - [macOS](#3-macos)
     - [Android](#4-android)
     - [iOS](#5-ios)
+- [Community Projects](#community-projects)
 - [TEN Ecosystem](#ten-ecosystem)
 - [Ask Questions](#ask-questions)
 - [Citations](#citations)
@@ -712,6 +713,18 @@ cd ./examples
       - Specify your Certification
 
         3.5. Build in Xcode and run demo on your device.
+
+<br>
+
+## Community Projects
+
+Third-party integrations and implementations built by the community.
+
+| Project | Language | Description |
+| ------- | -------- | ----------- |
+| [**wavekat-vad**](https://github.com/wavekat/wavekat-vad) | Rust | Pure Rust implementation using the ONNX model with a native preprocessing pipeline (pre-emphasis, STFT, mel filterbank, pitch estimation). No C library dependencies. |
+
+> Have a project using TEN VAD? Feel free to open a PR to add it here!
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -722,7 +722,7 @@ Third-party integrations and implementations built by the community.
 
 | Project | Language | Description |
 | ------- | -------- | ----------- |
-| [**wavekat-vad**](https://github.com/wavekat/wavekat-vad) | Rust | Pure Rust implementation using the ONNX model with a native preprocessing pipeline (pre-emphasis, STFT, mel filterbank, pitch estimation). No C library dependencies. |
+| [**wavekat&#8209;vad**](https://github.com/wavekat/wavekat-vad) | Rust | Pure Rust ONNX implementation with native preprocessing. No C dependencies. |
 
 > Have a project using TEN VAD? Feel free to open a PR to add it here!
 


### PR DESCRIPTION
## Summary
- Adds a new **Community Projects** section to the README to highlight third-party integrations and implementations
- Lists [wavekat-vad](https://github.com/wavekat/wavekat-vad) as a pure Rust implementation of TEN VAD (ONNX model, native preprocessing pipeline, no C dependencies)
- Includes an open invite for other community projects to add themselves

## Why a separate section?
The existing Quick Start sections are all first-party, built-in implementations. Community projects live in separate repos, so a dedicated section keeps things organized and makes it easy for others to contribute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)